### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,36 @@
 language: python
-env:
-- TOXENV=packaging
-- TOXENV=pep8
-- TOXENV=py3pep8
-- TOXENV=py27
-- TOXENV=py33
-- TOXENV=py34
-- TOXENV=pypy
+
+# tell travis to cache ~/.cache/pip
+cache: pip
+
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=packaging
+      
+    - python: 2.7
+      env: TOXENV=pep8
+
+    - python: 3.6
+      env: TOXENV=py3pep8
+
+    - python: 2.7
+      env: TOXENV=py27
+
+    - python: 3.3
+      env: TOXENV=py33
+
+    - python: 3.4
+      env: TOXENV=py34
+    
+    - python: 3.5
+      env: TOXENV=py35
+
+    - python: 3.6
+      env: TOXENV=py36
+
+    - python: pypy
+      env: TOXENV=pypy
 
 install:
 - pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = packaging, pep8, py3pep8, py27, py33, py34, pypy
+envlist = packaging, pep8, py3pep8, py26, py27, py33, py34, py35, py36, pypy
 
 [testenv]
 deps =
@@ -22,7 +22,7 @@ deps =
 commands = flake8 .
 
 [testenv:py3pep8]
-basepython = python3.4
+basepython = python3.6
 deps =
     flake8
 commands = flake8 .


### PR DESCRIPTION
Use a build matrix to check we get the right python versions

Might as well add 3.5 and 3.6 while we're here