### PR TITLE
Remove simplejson dependency

### DIFF
--- a/canonicaljson.py
+++ b/canonicaljson.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
-import re
-from six import unichr, PY2, PY3
 
 from frozendict import frozendict
 
@@ -33,19 +31,13 @@ def _default(obj):
                     obj.__class__.__name__)
 
 
-# ideally we'd set ensure_ascii=False, but the ensure_ascii codepath is so
-# much quicker (assuming c speedups are enabled) that it's actually much
-# quicker to let it do that and then substitute back (it's about 2.5x faster).
-#
-# (in any case, simplejson's ensure_ascii doesn't get U+2028 and U+2029 right,
-# as per https://github.com/simplejson/simplejson/issues/206).
-#
 _canonical_encoder = json.JSONEncoder(
-    ensure_ascii=True,
+    ensure_ascii=False,
     separators=(',', ':'),
     sort_keys=True,
     default=_default,
 )
+
 
 _pretty_encoder = json.JSONEncoder(
     ensure_ascii=True,
@@ -53,87 +45,6 @@ _pretty_encoder = json.JSONEncoder(
     sort_keys=True,
     default=_default,
 )
-
-# This regexp matches either `\uNNNN` or `\\`. We match '\\' (and leave it
-# unchanged) to make sure that the regex doesn't accidentally capture the uNNNN
-# in `\\uNNNN`, which is an escaped backslash followed by 'uNNNN'.
-_U_ESCAPE = re.compile(r"\\u([0-9a-f]{4})|\\\\")
-
-
-def _unascii(s):
-    """Unpack `\\uNNNN` escapes in 's' and encode the result as UTF-8
-
-    This method takes the output of the JSONEncoder and expands any \\uNNNN
-    escapes it finds (except for \\u0000 to \\u001F, which are converted to
-    \\xNN escapes).
-
-    For performance, it assumes that the input is valid JSON, and performs few
-    sanity checks.
-    """
-
-    # make the fast path fast: if there are no matches in the string, the
-    # whole thing is ascii. On python 2, that means we're done. On python 3,
-    # we have to turn it into a bytes, which is quickest with encode('utf-8')
-    m = _U_ESCAPE.search(s)
-    if not m:
-        return s if PY2 else s.encode('utf-8')
-
-    # appending to a string (or a bytes) is slooow, so we accumulate sections
-    # of string result in 'chunks', and join them all together later.
-    # (It doesn't seem to make much difference whether we accumulate
-    # utf8-encoded bytes, or strings which we utf-8 encode after rejoining)
-    #
-    chunks = []
-
-    # 'pos' tracks the index in 's' that we have processed into 'chunks' so
-    # far.
-    pos = 0
-
-    while m:
-        start = m.start()
-        end = m.end()
-
-        g = m.group(1)
-
-        if g is None:
-            # escaped backslash: pass it through along with anything before the
-            # match
-            chunks.append(s[pos:end])
-        else:
-            # \uNNNN, but we have to watch out for surrogate pairs.
-            #
-            # On python 2, str.encode("utf-8") will decode utf-16 surrogates
-            # before re-encoding, so it's fine for us to pass the surrogates
-            # through. (Indeed we must, to deal with UCS-2 python builds, per
-            # https://github.com/matrix-org/python-canonicaljson/issues/12).
-            #
-            # On python 3, str.encode("utf-8") complains about surrogates, so
-            # we have to unpack them.
-            c = int(g, 16)
-
-            if c < 0x20:
-                # leave as a \uNNNN escape
-                chunks.append(s[pos:end])
-            else:
-                if PY3:   # pragma nocover
-                    if c & 0xfc00 == 0xd800 and s[end:end + 2] == '\\u':
-                        esc2 = s[end + 2:end + 6]
-                        c2 = int(esc2, 16)
-                        if c2 & 0xfc00 == 0xdc00:
-                            c = 0x10000 + (((c - 0xd800) << 10) |
-                                           (c2 - 0xdc00))
-                            end += 6
-
-                chunks.append(s[pos:start])
-                chunks.append(unichr(c))
-
-        pos = end
-        m = _U_ESCAPE.search(s, pos)
-
-    # pass through anything after the last match
-    chunks.append(s[pos:])
-
-    return (''.join(chunks)).encode("utf-8")
 
 
 def encode_canonical_json(json_object):
@@ -145,8 +56,9 @@ def encode_canonical_json(json_object):
 
     Returns:
         bytes encoding the JSON object"""
+
     s = _canonical_encoder.encode(json_object)
-    return _unascii(s)
+    return s.encode("UTF-8")
 
 
 def encode_pretty_printed_json(json_object):

--- a/canonicaljson.py
+++ b/canonicaljson.py
@@ -14,22 +14,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import json
 import re
-import platform
 from six import unichr, PY2, PY3
 
 from frozendict import frozendict
-
-if platform.python_implementation() == "PyPy":  # pragma: no cover
-    # pypy ships with an optimised JSON encoder/decoder that is faster than
-    # simplejson's C extension.
-    import json
-else:  # pragma: no cover
-    # using simplejson rather than regular json on CPython gives approximately
-    # a 100% performance improvement (as measured on python 2.7.12/simplejson
-    # 3.13.2)
-    import simplejson as json
 
 
 __version__ = '1.1.4'

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
     description="Canonical JSON",
     install_requires=[
         "frozendict>=1.0",
-        "six",
     ],
     zip_safe=True,
     long_description=read_file(("README.rst",)),

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
     py_modules=["canonicaljson"],
     description="Canonical JSON",
     install_requires=[
-        "simplejson>=3.6.5",
         "frozendict>=1.0",
         "six",
     ],


### PR DESCRIPTION
Per some of the benchmarking done in matrix-org/synapse#7674 it seems that it might be beneficial to stop using simplejson. I'm putting up this PR so I can fetch it in tests on synapse and such.