### PR TITLE
Bump macOS build to Python 3.8 and update python 3 versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,18 +21,21 @@ matrix:
       language: generic
       env: TOXENV=py27
 
-    - python: 3.4
-      env: TOXENV=py34
-    
     - python: 3.5
       env: TOXENV=py35
 
     - python: 3.6
       env: TOXENV=py36
 
+    - python: 3.7
+      env: TOXENV=py37
+
+    - python: 3.8
+      env: TOXENV=py38
+
     - os: osx
       language: generic
-      env: TOXENV=py36
+      env: TOXENV=py38
 
     - python: pypy
       env: TOXENV=pypy

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -10,8 +10,8 @@ if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
             sudo `dirname $0`/get-pip.py
             sudo pip install tox
             ;;
-        py36)
-            # for py36, use homebrew python, which comes with pip.
+        py38)
+            # for py38, use homebrew python, which comes with pip.
             # see also https://docs.brew.sh/Homebrew-and-Python
             brew upgrade python
             pip3 install tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = packaging, pep8, py3pep8, py26, py27, py33, py34, py35, py36, pypy
+envlist = packaging, pep8, py3pep8, py26, py27, py35, py36, py37, py38, pypy
 
 [testenv]
 deps =


### PR DESCRIPTION
* Changes the macOS Python 3 build to use 3.8 (which is what is in homebrew now).
* Drops support for Python 3.3 and 3.4 as they're EOL.
* Adds support for Python 3.7 and 3.8.

I should note that this is all CI / tox changes. Nothing needs to be changed in the code.

Fixes #20