### PR TITLE
Prepare for release of 1.2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+Version 1.2.0 released 2020-07-27
+
+* JSON from the standard library is used automatically on PyPy.
+* Support for Python versions which are end-of-lifed was dropped, Python >= 3.5
+  is supported and tested in continuous integration.
+* An API to configure the underlying JSON library was added (`set_json_library`).
+
 Version 1.1.4 released 2018-05-23
 
  * Fix error when encoding non-BMP characters on UCS-2 python builds
@@ -21,9 +28,9 @@ Version 1.1.1 released 2018-04-11
 Version 1.1.0 released 2018-04-06
 
  * Significant performance improvements
-   (https://github.com/matrix-org/python-canonicaljson/pull/7,
-   https://github.com/matrix-org/python-canonicaljson/pull/8,
-   https://github.com/matrix-org/python-canonicaljson/pull/9)
+   ([\#7](https://github.com/matrix-org/python-canonicaljson/pull/7),
+   [\#8](https://github.com/matrix-org/python-canonicaljson/pull/8),
+   [\#9](https://github.com/matrix-org/python-canonicaljson/pull/9))
 
 Version 1.0.0 released 2015-08-21
 

--- a/README.rst
+++ b/README.rst
@@ -38,3 +38,18 @@ Using
 
     import canonicaljson
     assert canonicaljson.encode_canonical_json({}) == b'{}'
+
+The underlying JSON implementation can be choosen with the following:
+
+.. code:: python
+
+    import json
+    import canonicaljson
+    canonicaljson.set_json_library(json)
+
+.. note::
+
+    By default canonicaljson uses `simplejson`_ under the hood (except for PyPy,
+    which uses the standard library json module).
+
+.. _simplejson: https://simplejson.readthedocs.io/

--- a/canonicaljson.py
+++ b/canonicaljson.py
@@ -20,7 +20,7 @@ import platform
 
 from frozendict import frozendict
 
-__version__ = '1.1.4'
+__version__ = '1.2.0'
 
 
 def _default(obj):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[bdist_wheel]
-# we can generate universal wheels that support both Python 2 and Python 3.
-universal=1

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
     author_email='team@matrix.org',
     url='https://github.com/matrix-org/python-canonicaljson',
     license='Apache License, Version 2.0',
+    python_requires="~=3.5",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
This updates the changelog, bumps versions, etc. for release of 1.2.0.

A couple of things:
* Adds `python_requires` to setup.py.
* Removes setup.cfg since the wheels aren't universal (since Python 2 support was dropped).