### PR TITLE
Do not emit Infinity / -Infinity / NaN values from canonicaljson.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+Version next
+
+* Fix producing non-standard JSON for Infinity, -Infinity, and NaN. This could
+  error when encoding objects into canonical JSON that previously used to work,
+  but were incompatible with JSON implementations in other languages.
+
 Version 1.3.0 released 2020-08-14
 
 * The minimum version of simplejson was bumped to 3.14.0.

--- a/canonicaljson.py
+++ b/canonicaljson.py
@@ -48,12 +48,16 @@ def set_json_library(json_lib):
     """
     global _canonical_encoder
     _canonical_encoder = json_lib.JSONEncoder(
-        ensure_ascii=False, separators=(",", ":"), sort_keys=True, default=_default,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+        default=_default,
     )
 
     global _pretty_encoder
     _pretty_encoder = json_lib.JSONEncoder(
-        ensure_ascii=False, indent=4, sort_keys=True, default=_default,
+        ensure_ascii=False, allow_nan=False, indent=4, sort_keys=True, default=_default,
     )
 
 

--- a/test_canonicaljson.py
+++ b/test_canonicaljson.py
@@ -119,7 +119,7 @@ class TestCanonicalJson(unittest.TestCase):
             encode_pretty_printed_json(unknown_object)
 
     def test_invalid_float_values(self):
-        """Infinity/-Infinity/NaN are now allowed in canonicaljson.
+        """Infinity/-Infinity/NaN are not allowed in canonicaljson.
         """
 
         with self.assertRaises(ValueError):

--- a/test_canonicaljson.py
+++ b/test_canonicaljson.py
@@ -14,6 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from math import inf, nan
 
 from canonicaljson import (
     encode_canonical_json,
@@ -113,6 +114,31 @@ class TestCanonicalJson(unittest.TestCase):
         unknown_object = Unknown()
         with self.assertRaises(Exception):
             encode_canonical_json(unknown_object)
+
+        with self.assertRaises(Exception):
+            encode_pretty_printed_json(unknown_object)
+
+    def test_invalid_float_values(self):
+        """Infinity/-Infinity/NaN are now allowed in canonicaljson.
+        """
+
+        with self.assertRaises(ValueError):
+            encode_canonical_json(inf)
+
+        with self.assertRaises(ValueError):
+            encode_pretty_printed_json(inf)
+
+        with self.assertRaises(ValueError):
+            encode_canonical_json(-inf)
+
+        with self.assertRaises(ValueError):
+            encode_pretty_printed_json(-inf)
+
+        with self.assertRaises(ValueError):
+            encode_canonical_json(nan)
+
+        with self.assertRaises(ValueError):
+            encode_pretty_printed_json(nan)
 
     def test_set_json(self):
         """Ensure that changing the underlying JSON implementation works."""


### PR DESCRIPTION
Per matrix-org/synapse#8106, we shouldn't be serializing these values to JSON since they're not standard JSON.