### PR TITLE
Extend compatibility to C implementation of frozendict

### DIFF
--- a/canonicaljson.py
+++ b/canonicaljson.py
@@ -29,6 +29,9 @@ def _default(obj):
         try:
             return obj._dict
         except AttributeError:
+            # When the C implementation of frozendict is used,
+            # there isn't a `_dict` attribute with a dict
+            # so we resort to making a copy of the frozendict
             return dict(obj)
     raise TypeError(
         "Object of type %s is not JSON serializable" % obj.__class__.__name__

--- a/canonicaljson.py
+++ b/canonicaljson.py
@@ -26,7 +26,10 @@ def _default(obj):
     if type(obj) is frozendict:
         # fishing the protected dict out of the object is a bit nasty,
         # but we don't really want the overhead of copying the dict.
-        return obj._dict
+        try:
+            return obj._dict
+        except AttributeError:
+            return dict(obj)
     raise TypeError(
         "Object of type %s is not JSON serializable" % obj.__class__.__name__
     )


### PR DESCRIPTION
Fixes issue #36. 
Background: some versions of `frozendict` contain a C implementation of `frozendict` that was incompatible with our code. This PR adds logic to catch and handle those cases.  