### PR TITLE
Type annotations for canonicaljson

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,10 @@
 name: Tests
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -9,6 +13,7 @@ jobs:
         toxenv:
           - "pep8"
           - "black"
+          - "mypy"
 
     steps:
       - uses: actions/checkout@v2

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,6 @@ include *.py
 include *.md
 include LICENSE
 include tox.ini
+include pyproject.toml
 prune .travis
 prune debian

--- a/canonicaljson.py
+++ b/canonicaljson.py
@@ -89,55 +89,44 @@ def set_json_library(json_lib: JsonLibrary) -> None:
     )
 
 
-def encode_canonical_json(json_object: object) -> bytes:
-    """Encodes the shortest UTF-8 JSON encoding with dictionary keys
+def encode_canonical_json(data: object) -> bytes:
+    """Encodes the given `data` as a UTF-8 canonical JSON bytestring.
+
+    This encoding is the shortest possible. Dictionary keys are
     lexicographically sorted by unicode code point.
-
-    Args:
-        json_object (dict): The JSON object to encode.
-
-    Returns:
-        bytes encoding the JSON object"""
-    s = _canonical_encoder.encode(json_object)
+    """
+    s = _canonical_encoder.encode(data)
     return s.encode("utf-8")
 
 
-def iterencode_canonical_json(json_object: object) -> Generator[bytes, None, None]:
-    """Encodes the shortest UTF-8 JSON encoding with dictionary keys
+def iterencode_canonical_json(data: object) -> Generator[bytes, None, None]:
+    """Iteratively encodes the given `data` as a UTF-8 canonical JSON bytestring.
+
+    This yields one or more bytestrings; concatenating them all together yields the
+    full encoding of `data`. Building up the encoding gradually in this way allows us to
+    encode large pieces of `data` without blocking other tasks.
+
+    This encoding is the shortest possible. Dictionary keys are
     lexicographically sorted by unicode code point.
-
-    Args:
-        json_object (dict): The JSON object to encode.
-
-    Returns:
-        generator which yields bytes encoding the JSON object"""
-    for chunk in _canonical_encoder.iterencode(json_object):
+    """
+    for chunk in _canonical_encoder.iterencode(data):
         yield chunk.encode("utf-8")
 
 
-def encode_pretty_printed_json(json_object: object) -> bytes:
+def encode_pretty_printed_json(data: object) -> bytes:
+    """Encodes the given `data` as a UTF-8 human-readable JSON bytestring."""
+
+    return _pretty_encoder.encode(data).encode("utf-8")
+
+
+def iterencode_pretty_printed_json(data: object) -> Generator[bytes, None, None]:
+    """Iteratively encodes the given `data` as a UTF-8 human-readable JSON bytestring.
+
+    This yields one or more bytestrings; concatenating them all together yields the
+    full encoding of `data`. Building up the encoding gradually in this way allows us to
+    encode large pieces of `data` without blocking other tasks.
     """
-    Encodes the JSON object dict as human readable UTF-8 bytes.
-
-    Args:
-        json_object (dict): The JSON object to encode.
-
-    Returns:
-        bytes encoding the JSON object"""
-
-    return _pretty_encoder.encode(json_object).encode("utf-8")
-
-
-def iterencode_pretty_printed_json(json_object: object) -> Generator[bytes, None, None]:
-    """Encodes the JSON object dict as human readable UTF-8 bytes.
-
-    Args:
-        json_object (dict): The JSON object to encode.
-
-    Returns:
-        generator which yields bytes encoding the JSON object"""
-
-    for chunk in _pretty_encoder.iterencode(json_object):
+    for chunk in _pretty_encoder.iterencode(data):
         yield chunk.encode("utf-8")
 
 

--- a/canonicaljson.py
+++ b/canonicaljson.py
@@ -59,7 +59,7 @@ class JsonLibrary(Protocol):
 # Declare these in the module scope, but they get configured in
 # set_json_library.
 _canonical_encoder: Encoder = None  # type: ignore[assignment]
-_pretty_encoder: Encoder = None   # type: ignore[assignment]
+_pretty_encoder: Encoder = None  # type: ignore[assignment]
 
 
 def set_json_library(json_lib: JsonLibrary) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.mypy]
+show_error_codes = true
+strict = true
+
+files = ["."]
+exclude = "setup.py"
+#mypy_path = "stubs"
+
+#[[tool.mypy.overrides]]
+#module = [
+#    "idna",
+#    "netaddr",
+#    "prometheus_client",
+#    "signedjson.*",
+#    "sortedcontainers",
+#]
+#ignore_missing_imports = true
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,15 +4,3 @@ strict = true
 
 files = ["."]
 exclude = "setup.py"
-#mypy_path = "stubs"
-
-#[[tool.mypy.overrides]]
-#module = [
-#    "idna",
-#    "netaddr",
-#    "prometheus_client",
-#    "signedjson.*",
-#    "sortedcontainers",
-#]
-#ignore_missing_imports = true
-

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,8 @@ setup(
         # simplerjson versions before 3.14.0 had a bug with some characters
         # (e.g. \u2028) if ensure_ascii was set to false.
         "simplejson>=3.14.0",
+        # typing.Protocol was only added to the stdlib in Python 3.8
+        "typing_extensions>=4.0.0; python_version < '3.8'",
     ],
     extras_require={
         # frozendict support can be enabled using the `canonicaljson[frozendict]` syntax

--- a/test_canonicaljson.py
+++ b/test_canonicaljson.py
@@ -31,7 +31,7 @@ from unittest import mock
 
 
 class TestCanonicalJson(unittest.TestCase):
-    def test_encode_canonical(self):
+    def test_encode_canonical(self) -> None:
         self.assertEqual(encode_canonical_json({}), b"{}")
 
         # ctrl-chars should be encoded.
@@ -68,7 +68,7 @@ class TestCanonicalJson(unittest.TestCase):
         # Iteratively encoding should work.
         self.assertEqual(list(iterencode_canonical_json({})), [b"{}"])
 
-    def test_ascii(self):
+    def test_ascii(self) -> None:
         """
         Ensure the proper ASCII characters are escaped.
 
@@ -95,10 +95,10 @@ class TestCanonicalJson(unittest.TestCase):
         # And other characters are passed unescaped.
         unescaped = [0x20, 0x21] + list(range(0x23, 0x5C)) + list(range(0x5D, 0x7E))
         for c in unescaped:
-            c = chr(c)
-            self.assertEqual(encode_canonical_json(c), b'"' + c.encode("ascii") + b'"')
+            s = chr(c)
+            self.assertEqual(encode_canonical_json(s), b'"' + s.encode("ascii") + b'"')
 
-    def test_encode_pretty_printed(self):
+    def test_encode_pretty_printed(self) -> None:
         self.assertEqual(encode_pretty_printed_json({}), b"{}")
         self.assertEqual(list(iterencode_pretty_printed_json({})), [b"{}"])
 
@@ -112,7 +112,9 @@ class TestCanonicalJson(unittest.TestCase):
         frozendict_type is None,
         "If `frozendict` is not available, skip test",
     )
-    def test_frozen_dict(self):
+    def test_frozen_dict(self) -> None:
+        # For mypy's benefit:
+        assert frozendict_type is not None
         self.assertEqual(
             encode_canonical_json(frozendict_type({"a": 1})),
             b'{"a":1}',
@@ -122,7 +124,7 @@ class TestCanonicalJson(unittest.TestCase):
             b'{\n    "a": 1\n}',
         )
 
-    def test_unknown_type(self):
+    def test_unknown_type(self) -> None:
         class Unknown(object):
             pass
 
@@ -133,7 +135,7 @@ class TestCanonicalJson(unittest.TestCase):
         with self.assertRaises(Exception):
             encode_pretty_printed_json(unknown_object)
 
-    def test_invalid_float_values(self):
+    def test_invalid_float_values(self) -> None:
         """Infinity/-Infinity/NaN are not allowed in canonicaljson."""
 
         with self.assertRaises(ValueError):
@@ -154,7 +156,7 @@ class TestCanonicalJson(unittest.TestCase):
         with self.assertRaises(ValueError):
             encode_pretty_printed_json(nan)
 
-    def test_set_json(self):
+    def test_set_json(self) -> None:
         """Ensure that changing the underlying JSON implementation works."""
         mock_json = mock.Mock(spec=["JSONEncoder"])
         mock_json.JSONEncoder.return_value.encode.return_value = "sentinel"
@@ -163,6 +165,6 @@ class TestCanonicalJson(unittest.TestCase):
             self.assertEqual(encode_canonical_json({}), b"sentinel")
         finally:
             # Reset the JSON library to whatever was originally set.
-            from canonicaljson import json
+            from canonicaljson import json  # type: ignore[attr-defined]
 
             set_json_library(json)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = packaging, pep8, py37, py38, py39, py310, pypy3
+envlist = packaging, pep8, black, py37, py38, py39, py310, pypy3
 
 [testenv]
 deps =
@@ -25,6 +25,8 @@ commands = flake8 .
 basepython = python3.7
 deps =
     black==21.9b0
+    # Workaround black+click incompatability, see https://github.com/psf/black/issues/2964
+    click==8.0.4
 commands = python -m black --check --diff .
 
 [testenv:mypy]

--- a/tox.ini
+++ b/tox.ini
@@ -26,3 +26,11 @@ basepython = python3.7
 deps =
     black==21.9b0
 commands = python -m black --check --diff .
+
+[testenv:mypy]
+deps =
+    mypy==0.942
+    types-frozendict==2.0.8
+    types-simplejson==3.17.5
+    types-setuptools==57.4.14
+commands = mypy


### PR DESCRIPTION
`tox` passes locally for me.