### PR TITLE
Remove unused `setuptools_scm` build requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,5 @@ files = ["."]
 [build-system]
 requires = [
     "setuptools >= 35.0.2",
-    "setuptools_scm >= 2.0.0, <3"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
#52 introduced a build dependency on `setuptools_scm`.

According to https://github.com/pypa/setuptools_scm, usage of
`setuptools_scm` involves either a `[tool.setuptools_scm]` section in
`pyproject.toml`, or `use_scm_version=True` in `setup.py`. We do neither
of those things, so this build requirement ought to be safe to remove.

Resolves #53.

Signed-off-by: Sean Quah <seanq@matrix.org>