### PR TITLE
Various clean-ups

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -57,7 +57,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11""]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: "3.7"
       - run: pip install tox
       - run: tox -e ${{ matrix.toxenv }}
 
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.7']
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.7"]
 
     steps:
       - uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11""]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         toxenv:
           - "pep8"
+          - "isort"
           - "black"
           - "mypy"
 

--- a/README.rst
+++ b/README.rst
@@ -45,21 +45,6 @@ There's also an iterator version:
     import canonicaljson
     assert b''.join(canonicaljson.iterencode_canonical_json({})) == b'{}'
 
-The underlying JSON implementation can be chosen with the following:
-
-.. code:: python
-
-    import json
-    import canonicaljson
-    canonicaljson.set_json_library(json)
-
-.. note::
-
-    By default canonicaljson uses `simplejson`_ under the hood (except for PyPy,
-    which uses the standard library json module).
-
-.. _simplejson: https://simplejson.readthedocs.io/
-
 A preserialisation hook allows you to encode objects which aren't encodable by the
 standard library ``JSONEncoder``.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,9 +28,12 @@ packages =
 [options.package_data]
 canonicaljson = py.typed
 
-
 [flake8]
 # see https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
 # for error codes. The ones we ignore are:
 #  E501: Line too long (black enforces this for us)
 ignore=E501
+
+[isort]
+profile=black
+src_paths=src,tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
-    Programming Language :: Python :: 2
     Programming Language :: Python :: 3
 
 

--- a/src/canonicaljson/__init__.py
+++ b/src/canonicaljson/__init__.py
@@ -17,7 +17,6 @@ import functools
 import json
 from typing import Callable, Generator, Type, TypeVar
 
-
 __version__ = "2.0.0"
 
 

--- a/tests/test_canonicaljson.py
+++ b/tests/test_canonicaljson.py
@@ -34,7 +34,7 @@ class TestCanonicalJson(unittest.TestCase):
 
         # ctrl-chars should be encoded.
         self.assertEqual(
-            encode_canonical_json(u"text\u0003\r\n"),
+            encode_canonical_json("text\u0003\r\n"),
             b'"text\\u0003\\r\\n"',
         )
 
@@ -46,20 +46,20 @@ class TestCanonicalJson(unittest.TestCase):
 
         # non-ascii should come out utf8-encoded.
         self.assertEqual(
-            encode_canonical_json({u"la merde amusée": u"💩"}),
+            encode_canonical_json({"la merde amusée": "💩"}),
             b'{"la merde amus\xc3\xa9e":"\xF0\x9F\x92\xA9"}',
         )
 
         # so should U+2028 and U+2029
         self.assertEqual(
-            encode_canonical_json({u"spaces": u"\u2028 \u2029"}),
+            encode_canonical_json({"spaces": "\u2028 \u2029"}),
             b'{"spaces":"\xe2\x80\xa8 \xe2\x80\xa9"}',
         )
 
         # but we need to watch out for 'u1234' after backslash, which should
         # get encoded to an escaped backslash, followed by u1234
         self.assertEqual(
-            encode_canonical_json(u"\\u1234"),
+            encode_canonical_json("\\u1234"),
             b'"\\\\u1234"',
         )
 
@@ -102,7 +102,7 @@ class TestCanonicalJson(unittest.TestCase):
 
         # non-ascii should come out utf8-encoded.
         self.assertEqual(
-            encode_pretty_printed_json({u"la merde amusée": u"💩"}),
+            encode_pretty_printed_json({"la merde amusée": "💩"}),
             b'{\n    "la merde amus\xc3\xa9e": "\xF0\x9F\x92\xA9"\n}',
         )
 

--- a/tests/test_canonicaljson.py
+++ b/tests/test_canonicaljson.py
@@ -13,9 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from unittest.mock import Mock
-
+import unittest
 from math import inf, nan
+from unittest.mock import Mock
 
 from canonicaljson import (
     encode_canonical_json,
@@ -24,8 +24,6 @@ from canonicaljson import (
     iterencode_pretty_printed_json,
     register_preserialisation_callback,
 )
-
-import unittest
 
 
 class TestCanonicalJson(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,9 @@ isolated_build = True
 [testenv:py]
 deps =
     coverage
-    nose2
 
 commands =
-    coverage run --source canonicaljson -m nose2
+    coverage run --source canonicaljson -m unittest
     coverage report -m --fail-under 100
 
 [testenv:packaging]

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,12 @@ deps =
     flake8
 commands = flake8 src tests
 
+[testenv:isort]
+basepython = python3.7
+deps =
+    isort
+commands = isort --check src tests
+
 [testenv:black]
 basepython = python3.7
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -24,9 +24,7 @@ commands = flake8 src tests
 [testenv:black]
 basepython = python3.7
 deps =
-    black==21.9b0
-    # Workaround black+click incompatability, see https://github.com/psf/black/issues/2964
-    click==8.0.4
+    black==23.1.0
 commands = python -m black --check --diff src tests
 
 [testenv:mypy]


### PR DESCRIPTION
* Drop Python 2 classifier (the setup.cfg file already requires Python >= 3.7)
* Stop using nose2 and just use unittest directly
* Upgrade black & run it
* Run isort and ensure it is enforced
* Run tests on Python 3.11