### PR TITLE
Update and pin GitHub Actions; stop testing EOL Python 3.7-3.9 in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,6 +8,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  # Allow each job to check out the repo.
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-24.04

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-python@v6.2.0
         with:
-          python-version: "3.7"
+          python-version: "3.10"
       - run: pip install tox
       - run: tox -e ${{ matrix.toxenv }}
 
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.7"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v6.0.2
@@ -57,7 +57,7 @@ jobs:
     runs-on: macos-26
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v6.0.2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         toxenv:
@@ -20,22 +20,22 @@ jobs:
           - "mypy"
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.7"
       - run: pip install tox
       - run: tox -e ${{ matrix.toxenv }}
 
   unittest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.7"]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
@@ -48,20 +48,20 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-python@v6.2.0
       - run: python -m pip install tox
       - run: tox -e packaging
 
   macos-tests:
-    runs-on: macos-latest
+    runs-on: macos-26
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,8 +20,10 @@ jobs:
           - "mypy"
 
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.10"
       - run: pip install tox
@@ -34,8 +36,10 @@ jobs:
         python-version: ["3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
@@ -48,8 +52,10 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       - run: python -m pip install tox
       - run: tox -e packaging
 
@@ -60,8 +66,10 @@ jobs:
         python-version: ["3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+# Taken from https://github.com/zizmorcore/zizmor-action/blob/06928c5dcba418c7d6108a4bd6e2d34cbf3c9377/README.md
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = packaging, pep8, black, py37, py38, py39, py310, pypy3, mypy, isort
+envlist = packaging, pep8, black, py310, pypy3, mypy, isort
 isolated_build = True
 
 [testenv:py]
@@ -16,19 +16,19 @@ deps =
 commands = check-manifest
 
 [testenv:pep8]
-basepython = python3.7
+basepython = python3.10
 deps =
     flake8
 commands = flake8 src tests
 
 [testenv:isort]
-basepython = python3.7
+basepython = python3.10
 deps =
     isort
 commands = isort --check src tests
 
 [testenv:black]
-basepython = python3.7
+basepython = python3.10
 deps =
     black==23.1.0
 commands = python -m black --check --diff src tests


### PR DESCRIPTION
Updates the old GitHub Actions in use in this repository, and pins them to a specific hash.

We also drop testing the end-of-life Python versions 3.7-3.9 in CI. This allows CI to pass again. **Note:** This PR does not officially drop support for these Python versions.** Doing so requires updating `setup.cfg`. Let's do that in a separate PR ⏩

Finally, we add the [`zizmor` Github Action](https://github.com/zizmorcore/zizmor-action) so we prevent introducing any regressions in the security of our GitHub Actions.